### PR TITLE
Enable manual element pick with iframe

### DIFF
--- a/options.html
+++ b/options.html
@@ -247,6 +247,24 @@
           </div>
         </div>
 
+        <!-- Modal de Selecao Manual -->
+        <div class="modal fade" id="frameSelecaoModal" tabindex="-1" role="dialog" aria-labelledby="frameSelecaoModalLabel" aria-hidden="true">
+          <div class="modal-dialog modal-xl" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="frameSelecaoModalLabel">Selecione o Elemento do Preço</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Fechar">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+              </div>
+              <div class="modal-body">
+                <iframe id="previewFrame" style="width:100%;height:70vh;border:1px solid #ccc;"></iframe>
+                <p class="mt-2">Passe o mouse sobre os elementos para destacá-los e clique para selecionar.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- Modal para editar produto -->
         <div class="modal fade" id="editarProdutoModal" tabindex="-1" role="dialog" aria-labelledby="editarProdutoModalLabel" aria-hidden="true">
           <div class="modal-dialog" role="document">


### PR DESCRIPTION
## Summary
- allow picking a DOM element manually when adding a new product
- show the target page in a modal iframe
- highlight elements on hover and save the clicked selector

## Testing
- `node --check options.js`

------
https://chatgpt.com/codex/tasks/task_e_6846f371ce408328ae94355169bd959c