### PR TITLE
Adicionar verificação de apoiamentos

### DIFF
--- a/background.js
+++ b/background.js
@@ -48,6 +48,17 @@ if (typeof chrome === 'undefined' || typeof chrome.runtime === 'undefined' || ty
   const DB_NAME = 'MonitorDePrecosDB';
   const DB_VERSION = 1;
   let intervaloVerificacao = 120;
+  let intervaloApoiamentos = 60;
+  let ultimoTotalApoiamentos = null;
+
+  function carregarConfiguracoes(callback) {
+    chrome.storage.local.get(['intervaloTempo', 'intervaloApoiamentos', 'ultimoTotalApoiamentos'], (dados) => {
+      if (dados.intervaloTempo) intervaloVerificacao = parseInt(dados.intervaloTempo);
+      if (dados.intervaloApoiamentos) intervaloApoiamentos = parseInt(dados.intervaloApoiamentos);
+      if (dados.ultimoTotalApoiamentos) ultimoTotalApoiamentos = parseInt(dados.ultimoTotalApoiamentos);
+      if (typeof callback === 'function') callback();
+    });
+  }
 
   function inicializarBancoDados() {
     return new Promise((resolve, reject) => {
@@ -1010,6 +1021,103 @@ if (typeof chrome === 'undefined' || typeof chrome.runtime === 'undefined' || ty
     }
   }
 
+  async function verificarApoiamentos() {
+    try {
+      const headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.3351.34",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "pt-BR,pt;q=0.8,en-US;q=0.5,en;q=0.3",
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "X-Requested-With": "XMLHttpRequest"
+      };
+
+      const tseUrl = "https://www.tse.jus.br/partidos/criacao-de-partido/partidos-em-formacao";
+      const sapfUrl = "https://sapf.tse.jus.br/sapf-consulta/paginas/principal";
+      const listUrl = "https://sapf.tse.jus.br/sapf-consulta/paginas/partidoFormacao/listar";
+
+      await fetch(tseUrl, { headers, credentials: 'include' });
+      const sapfResp = await fetch(sapfUrl, { headers, credentials: 'include' });
+      if (!sapfResp.ok) throw new Error('Falha ao carregar SAPF');
+
+      const sapfText = await sapfResp.text();
+      const parser = new DOMParser();
+      const sapfDoc = parser.parseFromString(sapfText, 'text/html');
+      const viewstateInput = sapfDoc.querySelector('input[name="javax.faces.ViewState"]');
+      if (!viewstateInput) throw new Error('ViewState não encontrado');
+      const viewstate = viewstateInput.value;
+
+      const payload = new URLSearchParams({
+        "javax.faces.partial.ajax": "true",
+        "javax.faces.source": "partidoDataList",
+        "javax.faces.partial.execute": "partidoDataList",
+        "javax.faces.partial.render": "partidoDataList",
+        "partidoDataList": "partidoDataList",
+        "partidoDataList_pagination": "true",
+        "partidoDataList_first": "0",
+        "partidoDataList_rows": "100",
+        "partidoDataList_skipChildren": "true",
+        "partidoDataList_encodeFeature": "true",
+        "ListarPartidosForm": "ListarPartidosForm",
+        "partidoDataList_rppDD": "100",
+        "javax.faces.ViewState": viewstate
+      });
+
+      const listResp = await fetch(listUrl, { method: 'POST', headers, body: payload.toString(), credentials: 'include' });
+      if (!listResp.ok) throw new Error('Falha ao listar partidos');
+      const listText = await listResp.text();
+      const listDoc = new DOMParser().parseFromString(listText, 'application/xml');
+      const rows = Array.from(listDoc.querySelectorAll('tr[role="row"]'));
+      let targetRowId = null;
+      rows.forEach((row, idx) => {
+        const cnpjCell = row.querySelector('td.ui-column-cnpj');
+        if (cnpjCell && cnpjCell.textContent.includes('000103')) {
+          targetRowId = `partidoDataList:${idx}:j_idt36`;
+        }
+      });
+      if (!targetRowId) throw new Error('Partido desejado não encontrado');
+
+      const detailsPayload = new URLSearchParams({
+        "javax.faces.partial.ajax": "true",
+        "javax.faces.source": targetRowId,
+        "javax.faces.partial.execute": targetRowId,
+        "javax.faces.partial.render": "partidoDataList",
+        "partidoDataList": "partidoDataList",
+        "ListarPartidosForm": "ListarPartidosForm",
+        "javax.faces.ViewState": viewstate
+      });
+
+      const detailsResp = await fetch(listUrl, { method: 'POST', headers, body: detailsPayload.toString(), credentials: 'include' });
+      if (!detailsResp.ok) throw new Error('Falha ao obter detalhes');
+      const detailsText = await detailsResp.text();
+      const match = /Total de aptos: (\d+)/.exec(detailsText);
+      if (!match) throw new Error('Total de aptos não encontrado');
+
+      const totalAptos = parseInt(match[1], 10);
+      if (ultimoTotalApoiamentos === null || totalAptos !== ultimoTotalApoiamentos) {
+        ultimoTotalApoiamentos = totalAptos;
+        chrome.storage.local.set({ ultimoTotalApoiamentos: totalAptos });
+
+        const faltam = 547455 - totalAptos;
+        const mensagem =
+          "⬛️⬜️🟨 *MISSÃO* 🟨⬜️⬛️\n" +
+          "```---------------------------------- \n" +
+          "✅ Análise de Apoiamentos:\n" +
+          `| ✍️ Apoiamentos Atuais:  ${totalAptos.toLocaleString('pt-BR')}\n` +
+          "| 🎯 Meta de Apoiamentos: 547.455\n" +
+          "----------------------------------\n" +
+          `| 🔭 Faltam ${faltam.toLocaleString('pt-BR')} apoiamentos para atingir a meta.` +
+          "```";
+
+        const db = await inicializarBancoDados();
+        const config = await obterConfiguracoesTelegram(db);
+        await enviarNotificacaoTelegram(mensagem, config.botToken, config.chatId);
+        await adicionarLog(db, `Apoiamentos atualizados: ${totalAptos}`);
+      }
+    } catch (erro) {
+      console.error('Erro ao verificar apoiamentos:', erro);
+    }
+  }
+
   async function atualizarStatus(status) {
     chrome.runtime.sendMessage({ action: 'statusAtualizado', status: status }, function(response) {
       if (chrome.runtime.lastError) {
@@ -1216,24 +1324,38 @@ if (typeof chrome === 'undefined' || typeof chrome.runtime === 'undefined' || ty
     chrome.alarms.create('verificacaoTermo', { periodInMinutes: intervaloVerificacao });
   }
 
+  function agendarVerificacaoApoiamentos() {
+    chrome.alarms.create('verificacaoApoiamentos', { periodInMinutes: intervaloApoiamentos });
+  }
+
   chrome.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name === 'verificacaoPreco') {
       verificarPrecos();
     } else if (alarm.name === 'verificacaoTermo') {
       verificarTermos();
+    } else if (alarm.name === 'verificacaoApoiamentos') {
+      verificarApoiamentos();
     }
   });
 
   chrome.runtime.onInstalled.addListener(() => {
-    agendarVerificacao();
-    verificarPrecos();
-    verificarTermos();
+    carregarConfiguracoes(() => {
+      agendarVerificacao();
+      agendarVerificacaoApoiamentos();
+      verificarPrecos();
+      verificarTermos();
+      verificarApoiamentos();
+    });
   });
 
   chrome.runtime.onStartup.addListener(() => {
-    agendarVerificacao();
-    verificarPrecos();
-    verificarTermos();
+    carregarConfiguracoes(() => {
+      agendarVerificacao();
+      agendarVerificacaoApoiamentos();
+      verificarPrecos();
+      verificarTermos();
+      verificarApoiamentos();
+    });
   });
 
   chrome.action.onClicked.addListener(() => {
@@ -1418,11 +1540,25 @@ if (typeof chrome === 'undefined' || typeof chrome.runtime === 'undefined' || ty
         case 'definirIntervaloTempo':
           try {
             intervaloVerificacao = parseInt(request.intervaloTempo);
+            chrome.storage.local.set({ intervaloTempo: intervaloVerificacao });
             await adicionarLog(db, `Intervalo de verificação definido para ${intervaloVerificacao} minutos.`);
             chrome.alarms.clear('verificacaoPreco');
             chrome.alarms.create('verificacaoPreco', { periodInMinutes: intervaloVerificacao });
             chrome.alarms.clear('verificacaoTermo');
             chrome.alarms.create('verificacaoTermo', { periodInMinutes: intervaloVerificacao });
+            sendResponse({ success: true });
+          } catch (erro) {
+            sendResponse({ success: false, error: erro });
+          }
+          break;
+
+        case 'definirIntervaloApoiamentos':
+          try {
+            intervaloApoiamentos = parseInt(request.intervaloTempo);
+            chrome.storage.local.set({ intervaloApoiamentos: intervaloApoiamentos });
+            await adicionarLog(db, `Intervalo de apoiamentos definido para ${intervaloApoiamentos} minutos.`);
+            chrome.alarms.clear('verificacaoApoiamentos');
+            chrome.alarms.create('verificacaoApoiamentos', { periodInMinutes: intervaloApoiamentos });
             sendResponse({ success: true });
           } catch (erro) {
             sendResponse({ success: false, error: erro });

--- a/options.html
+++ b/options.html
@@ -159,6 +159,20 @@
           </div>
         </div>
 
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">Intervalo de Apoiamentos</h5>
+            <form id="intervaloApoiamentosForm" class="form-inline">
+              <div class="form-group mb-2">
+                <label for="intervaloApoiamentos" class="sr-only">Intervalo em minutos</label>
+                <input type="number" id="intervaloApoiamentos" class="form-control" placeholder="Intervalo em minutos" min="1" required>
+              </div>
+              <button type="submit" class="btn btn-secondary mb-2 ml-2">Salvar Intervalo</button>
+              <span class="current-interval" id="intervaloApoiamentosAtual"></span>
+            </form>
+          </div>
+        </div>
+
         <h2>Produtos Monitorados</h2>
         <table id="tabelaProdutos" class="table table-striped">
           <thead class="thead-dark">

--- a/options.js
+++ b/options.js
@@ -202,6 +202,7 @@ $(document).ready(function() {
 
   carregarStatus();
   carregarIntervaloTempo();
+  carregarIntervaloApoiamentos();
   carregarProdutos();
   carregarTermos();
   carregarConfiguracoesTelegram();
@@ -286,6 +287,11 @@ $(document).ready(function() {
   $('#intervaloForm').on('submit', function(e) {
     e.preventDefault();
     definirIntervaloTempo();
+  });
+
+  $('#intervaloApoiamentosForm').on('submit', function(e) {
+    e.preventDefault();
+    definirIntervaloApoiamentos();
   });
 
   $('#telegramForm').on('submit', function(e) {
@@ -537,6 +543,18 @@ function carregarIntervaloTempo() {
     var intervalo = dados.intervaloTempo || 120;
     $('#intervaloTempo').val(intervalo);
     $('#intervaloAtual').text('Intervalo atual: ' + intervalo + ' minutos');
+  });
+}
+
+function carregarIntervaloApoiamentos() {
+  chrome.storage.local.get(['intervaloApoiamentos'], function(dados) {
+    if (chrome.runtime.lastError) {
+      console.error('Erro ao obter intervalo de apoiamentos:', chrome.runtime.lastError);
+      return;
+    }
+    var intervalo = dados.intervaloApoiamentos || 60;
+    $('#intervaloApoiamentos').val(intervalo);
+    $('#intervaloApoiamentosAtual').text('Intervalo atual: ' + intervalo + ' minutos');
   });
 }
 
@@ -1240,6 +1258,28 @@ function definirIntervaloTempo() {
     if (response.success) {
       alert('Intervalo salvo com sucesso!');
       $('#intervaloAtual').text('Intervalo atual: ' + intervaloTempo + ' minutos');
+    } else {
+      alert('Erro ao salvar intervalo: ' + response.error);
+    }
+  });
+}
+
+function definirIntervaloApoiamentos() {
+  var intervalo = $('#intervaloApoiamentos').val();
+  if (!intervalo || intervalo <= 0) {
+    alert('Por favor, insira um intervalo válido em minutos.');
+    return;
+  }
+
+  chrome.runtime.sendMessage({ action: 'definirIntervaloApoiamentos', intervaloTempo: intervalo }, function(response) {
+    if (chrome.runtime.lastError) {
+      console.error('Erro ao definir intervalo de apoiamentos:', chrome.runtime.lastError);
+      alert('Erro ao salvar intervalo de apoiamentos. Verifique o console para mais detalhes.');
+      return;
+    }
+    if (response.success) {
+      alert('Intervalo salvo com sucesso!');
+      $('#intervaloApoiamentosAtual').text('Intervalo atual: ' + intervalo + ' minutos');
     } else {
       alert('Erro ao salvar intervalo: ' + response.error);
     }


### PR DESCRIPTION
## Resumo
- permitir configurar intervalo de verificação dos apoiamentos
- verificar apoiamentos no site do TSE e enviar aviso quando o número mudar
- salvar configuração e último valor no armazenamento local
- executar verificação agendada via alarmes

## Testes
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850f041439c832895e06aaf6f0d72b2